### PR TITLE
Feat (inf): Tailscale

### DIFF
--- a/apps/base/podinfo/release.yaml
+++ b/apps/base/podinfo/release.yaml
@@ -11,7 +11,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: podinfo
-  interval: 50m
+  interval: 12h
   install:
     remediation:
       retries: 3

--- a/apps/base/podinfo/repository.yaml
+++ b/apps/base/podinfo/repository.yaml
@@ -4,5 +4,5 @@ metadata:
   name: podinfo
   namespace: podinfo
 spec:
-  interval: 5m
+  interval: 24h
   url: https://stefanprodan.github.io/podinfo

--- a/infrastructure/configs/kustomization.yaml
+++ b/infrastructure/configs/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cluster-issuers.yaml
+  - tailscale.yaml

--- a/infrastructure/configs/tailscale.yaml
+++ b/infrastructure/configs/tailscale.yaml
@@ -1,0 +1,9 @@
+# Currently only supported for egress
+#https://tailscale.com/kb/1236/kubernetes-operator#optional-pre-creating-a-proxygroup
+apiVersion: tailscale.com/v1alpha1
+kind: ProxyGroup
+metadata:
+  name: ts-proxies
+spec:
+  type: egress
+  replicas: 3

--- a/infrastructure/controllers/kustomization.yaml
+++ b/infrastructure/controllers/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - cert-manager.yaml
   - traefik.yaml
+  - tailscale.yaml

--- a/infrastructure/controllers/tailscale.yaml
+++ b/infrastructure/controllers/tailscale.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailscale
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: tailscale
+  namespace: tailscale
+spec:
+  interval: 24h
+  url: https://pkgs.tailscale.com/helmcharts
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tailscale
+  namespace: tailscale
+spec:
+  releaseName: tailscale
+  chart:
+    spec:
+      chart: tailscale-operator
+      sourceRef:
+        kind: HelmRepository
+        name: tailscale
+        namespace: tailscale
+  interval: 12h
+  install:
+    remediation:
+      retries: 3
+  createNamespace: true
+  wait: true
+  namespace: tailscale
+  # Helm Chart auto mounts the secret named tailscale-oauth in the tailscale namespace
+  # https://github.com/tailscale/tailscale/blob/main/cmd/k8s-operator/deploy/chart/templates/deployment.yaml

--- a/infrastructure/controllers/traefik.yaml
+++ b/infrastructure/controllers/traefik.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -19,7 +18,7 @@ metadata:
   name: traefik
   namespace: traefik
 spec:
-  interval: 30m
+  interval: 12h
   dependsOn:
     - name: traefik-crds
   install:
@@ -48,7 +47,7 @@ metadata:
   name: traefik-crds
   namespace: traefik
 spec:
-  interval: 30m
+  interval: 12h
   chart:
     spec:
       chart: traefik-crds


### PR DESCRIPTION
Adds the tailscale-operator to it's own namespace in the cluster.

Also adds a ProxyGroup as a StatefulSet with 3 replicas. This will allow 0 downtime upgrades in future. Although, this is only supported for egress at the moment, will bump when ingress support is added.