### PR TITLE
Feat (inf): External-DNS

### DIFF
--- a/apps/base/podinfo/discord-alert.yaml
+++ b/apps/base/podinfo/discord-alert.yaml
@@ -2,7 +2,7 @@
 apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Provider
 metadata:
-  name: discord
+  name: discord-bot
   namespace: podinfo
 spec:
   type: discord
@@ -12,7 +12,7 @@ spec:
 apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Alert
 metadata:
-  name: discord
+  name: discord-alert
   namespace: podinfo
 spec:
   eventMetadata:

--- a/apps/base/podinfo/discord-alert.yaml
+++ b/apps/base/podinfo/discord-alert.yaml
@@ -3,7 +3,7 @@ apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Provider
 metadata:
   name: discord
-  namespace: default
+  namespace: podinfo
 spec:
   type: discord
   secretRef:

--- a/apps/base/podinfo/ingressroute-traefik.yaml
+++ b/apps/base/podinfo/ingressroute-traefik.yaml
@@ -4,6 +4,9 @@ kind: IngressRoute
 metadata:
   name: podinfo-ingressroute
   namespace: podinfo
+  annotations:
+    external-dns.io/hostname: podinfo.lab.biodrone.xyz
+    kubernetes.io/ingress.class: traefik
 spec:
   entryPoints:
     - websecure

--- a/infrastructure/configs/tailscale.yaml
+++ b/infrastructure/configs/tailscale.yaml
@@ -1,5 +1,5 @@
 # Currently only supported for egress
-#https://tailscale.com/kb/1236/kubernetes-operator#optional-pre-creating-a-proxygroup
+# https://tailscale.com/kb/1236/kubernetes-operator#optional-pre-creating-a-proxygroup
 apiVersion: tailscale.com/v1alpha1
 kind: ProxyGroup
 metadata:

--- a/infrastructure/controllers/external-dns-pihole.yaml
+++ b/infrastructure/controllers/external-dns-pihole.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-dns
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups: [""]
+  resources: ["services","endpoints","pods"]
+  verbs: ["get","watch","list"]
+- apiGroups: ["extensions","networking.k8s.io"]
+  resources: ["ingresses"]
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["list","watch"]
+- apiGroups: ["traefik.containo.us","traefik.io"]
+  resources: ["ingressroutes", "ingressroutetcps", "ingressrouteudps"]
+  verbs: ["get","watch","list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+  namespace: external-dns
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      serviceAccountName: external-dns
+      containers:
+      - name: external-dns
+        image: registry.k8s.io/external-dns/external-dns:v0.16.1
+        envFrom:
+        - secretRef:
+            name: pihole-password
+        args:
+        - --source=traefik-proxy
+        # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
+        # You don't need to set this flag, but if you leave it unset, you will receive warning
+        # logs when ExternalDNS attempts to create TXT records.
+        - --registry=noop
+        # IMPORTANT: If you have records that you manage manually in Pi-hole, set
+        # the policy to upsert-only so they do not get deleted.
+        - --policy=upsert-only
+        - --provider=pihole
+        - --pihole-api-version=6
+        - --pihole-server=https://pihole.home.biodrone.xyz
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "500m"
+          requests:
+            memory: "64Mi"
+            cpu: "250m"
+      securityContext:
+        fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes token files

--- a/infrastructure/controllers/external-dns-pihole.yaml
+++ b/infrastructure/controllers/external-dns-pihole.yaml
@@ -83,3 +83,42 @@ spec:
             cpu: "250m"
       securityContext:
         fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes token files
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: discord-bot
+  namespace: external-dns
+spec:
+  type: discord
+  secretRef:
+    name: discord-webhook
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: discord-alert
+  namespace: external-dns
+spec:
+  eventMetadata:
+    summary: "Something happened with external-dns"
+  providerRef:
+    name: discord-bot
+  eventSeverity: info
+  eventSources:
+    - kind: HelmChart
+      name: '*'
+    - kind: HelmRepository
+      name: '*'
+    - kind: HelmRelease
+      name: '*'
+    - kind: Kustomization
+      name: '*'
+    - kind: ImageRepository
+      name: '*'
+    - kind: ImagePolicy
+      name: '*'
+    - kind: ImageUpdateAutomation
+      name: '*'
+    - kind: GitRepository
+      name: '*'

--- a/infrastructure/controllers/kustomization.yaml
+++ b/infrastructure/controllers/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - cert-manager.yaml
   - traefik.yaml
   - tailscale.yaml
+  - external-dns-pihole.yaml


### PR DESCRIPTION
Adds External-DNS using Traefik ingressroutes as the provider and publishing to PiHole.

Fixes #10 