### PR TITLE
Enable Tailscale API Server Proxy for Kubernetes Control Plane Access

### DIFF
--- a/infrastructure/controllers/tailscale.yaml
+++ b/infrastructure/controllers/tailscale.yaml
@@ -31,5 +31,10 @@ spec:
   install:
     remediation:
       retries: 3
+  values:
+    # Enable API server proxy to expose Kubernetes control plane over Tailscale
+    # auth mode impersonates requests using the sender's tailnet identity for RBAC
+    apiServerProxyConfig:
+      mode: auth
   # Helm Chart auto mounts the secret named tailscale-oauth in the tailscale namespace
   # https://github.com/tailscale/tailscale/blob/main/cmd/k8s-operator/deploy/chart/templates/deployment.yaml


### PR DESCRIPTION
This PR enables the Tailscale Kubernetes Operator's API server proxy feature to expose the Kubernetes control plane over Tailscale's secure mesh network.

## Changes
- Added `apiServerProxyConfig.mode: auth` to the Tailscale HelmRelease values
- Enables secure access to the Kubernetes API server from anywhere in the tailnet
- Uses auth mode for RBAC with tailnet identity impersonation

## Related
Fixes #23

## Next Steps
After merging, the following steps will be required:
1. Wait for Flux to reconcile the HelmRelease
2. Configure Tailscale ACLs to allow access to the API server proxy (port 443)
3. Update kubeconfig using `tailscale configure kubeconfig <hostname>`