### PR TITLE
feat(inf): HashiCorp Vault installation

### DIFF
--- a/.cursor/rules/branch-naming.md
+++ b/.cursor/rules/branch-naming.md
@@ -1,0 +1,51 @@
+# Branch Naming Convention
+
+## Format
+
+Branches should include both the issue number and a descriptive name to make it easy to identify the purpose at a glance.
+
+**Format**: `biodrone/issue<number>-<short-description>`
+
+### Components
+
+- **Prefix**: `biodrone/` - Identifies the branch owner/namespace
+- **Issue Number**: `issue<number>` - Links to the GitHub issue (e.g., `issue27`)
+- **Description**: `<short-description>` - Brief, kebab-case description of what the branch is for
+
+### Examples
+
+✅ **Correct:**
+
+- `biodrone/issue27-vault` - Working on HashiCorp Vault (issue #27)
+- `biodrone/issue23-recipes` - Working on recipes app (issue #23)
+- `biodrone/issue6-cloudnative-pg` - Working on CloudNative-PG (issue #6)
+
+❌ **Incorrect:**
+
+- `biodrone/issue27` - Missing descriptive name
+- `biodrone/vault` - Missing issue number
+- `biodrone/issue-27-vault` - Uses dash in issue number (should be `issue27`)
+- `biodrone/issue27_hashicorp_vault` - Uses underscores instead of hyphens
+
+## Best Practices
+
+- **Use hyphens**: Separate words with hyphens (`-`) for better readability
+- **Be descriptive but concise**: Include enough detail to convey purpose without being overly long
+- **Use kebab-case**: All lowercase with hyphens (e.g., `hashicorp-vault`, not `HashiCorpVault`)
+- **Match issue title**: The description should relate to the issue title, but can be shortened/abbreviated
+
+## Workflow
+
+1. Check the issue number: `gh issue list` or view the issue on GitHub
+2. Create branch: `git checkout -b biodrone/issue<number>-<description>`
+3. Work on the branch and commit changes
+4. Push and create PR: `git push -u origin biodrone/issue<number>-<description>`
+
+## Rationale
+
+This naming convention provides:
+
+- **Traceability**: Issue number links branch to GitHub issue
+- **Clarity**: Descriptive name makes purpose immediately obvious
+- **Organization**: Consistent format makes branches easy to scan and manage
+- **Context**: Team members can quickly understand what each branch is for without checking the issue

--- a/.cursor/rules/issue-formatting.md
+++ b/.cursor/rules/issue-formatting.md
@@ -1,0 +1,63 @@
+# Homelab GitOps Repository Rules
+
+## Issue Formatting
+
+### Title Format
+
+- **Do NOT use conventional commit prefixes** (e.g., `feat(inf):`, `fix(app):`) in issue titles
+- Use clean, descriptive titles: `External Secrets Operator`, `HashiCorp Vault`, `StreamDL`
+- Titles should be concise and self-explanatory
+
+### Labels
+
+Issues must be labeled with:
+
+1. **Type Label** (required):
+   - `feat` - New feature or enhancement
+   - `fix` - Bug fix
+   - `docs` - Documentation changes
+
+2. **Scope Label** (required, matches Flux kustomization structure):
+   - `infra-controllers` - Infrastructure controllers and operators (matches `infrastructure/controllers/`)
+   - `infra-configs` - Infrastructure configuration (matches `infrastructure/configs/`)
+   - `apps` - Applications (matches `apps/`)
+   - `deps` - Dependencies and tooling
+   - `meta` - Meta/workflow improvements
+
+### Examples
+
+✅ **Correct:**
+
+- Title: `External Secrets Operator`
+- Labels: `feat`, `infra-controllers`
+
+- Title: `delegate certain zones to pihole dns`
+- Labels: `fix`, `infra-configs`
+
+- Title: `StreamDL`
+- Labels: `feat`, `apps`
+
+❌ **Incorrect:**
+
+- Title: `feat(inf): External Secrets Operator` (has conventional commit prefix)
+- Title: `External Secrets Operator` with no labels (missing type and scope)
+
+## Repository Structure
+
+This repository follows FluxCD GitOps patterns:
+
+- `infrastructure/controllers/` - Infrastructure controllers and operators
+- `infrastructure/configs/` - Infrastructure configuration
+- `apps/base/` - Base application configurations
+- `apps/homelab/` - Environment-specific application overlays
+- `clusters/homelab/` - Cluster-specific Flux kustomizations
+
+## Conventional Commits
+
+When creating commits (not issues), use conventional commit format:
+
+- `feat(scope): description`
+- `fix(scope): description`
+- `docs(scope): description`
+
+Scopes should match the directory structure (e.g., `inf`, `app`, `deps`, `meta`).

--- a/infrastructure/controllers/kustomization.yaml
+++ b/infrastructure/controllers/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - external-dns-pihole.yaml
   - nfs-provisioner.yaml
   - cloudnative-pg.yaml
+  - vault.yaml

--- a/infrastructure/controllers/vault.yaml
+++ b/infrastructure/controllers/vault.yaml
@@ -1,0 +1,143 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vault
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: hashicorp
+  namespace: vault
+spec:
+  interval: 24h
+  url: https://helm.releases.hashicorp.com
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vault
+  namespace: vault
+spec:
+  interval: 12h
+  chart:
+    spec:
+      chart: vault
+      version: "~0.27.0"
+      sourceRef:
+        kind: HelmRepository
+        name: hashicorp
+        namespace: vault
+      interval: 12h
+  values:
+    # Server configuration
+    server:
+      # Development mode - disabled for production use
+      dev:
+        enabled: false
+      # Standalone mode (single replica) - good for initial setup
+      # For production HA, set standalone.enabled: false and enable ha.raft
+      standalone:
+        enabled: true
+      # High Availability mode (disabled for initial setup)
+      # Enable this for production with Raft storage backend
+      ha:
+        enabled: false
+        replicas: 3
+        # Raft storage backend for HA (requires persistent storage)
+        raft:
+          enabled: false
+      # Data storage configuration for standalone mode
+      # Uses file storage backend by default
+      # Reference the explicit PVC created above
+      dataStorage:
+        enabled: true
+        existingClaim: vault-data
+        # Size and storageClass are ignored when using existingClaim
+        # but kept for reference
+        size: 10Gi
+        storageClass: nfs-truenas
+        accessMode: ReadWriteOnce
+      # Resource limits
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 250m
+          memory: 256Mi
+    # UI configuration - enables Vault web UI
+    ui:
+      enabled: true
+    # Service configuration
+    service:
+      enabled: true
+      type: ClusterIP
+      port: 8200
+    # Ingress configuration - using separate IngressRoute resource below
+    ingress:
+      enabled: false
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vault-data
+  namespace: vault
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: nfs-truenas
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: vault-certificate-production
+  namespace: vault
+spec:
+  secretName: vault-certificate-production
+  issuerRef:
+    name: cloudflare-clusterissuer-production
+    kind: ClusterIssuer
+  commonName: vault.lab.biodrone.xyz
+  dnsNames:
+    - vault.lab.biodrone.xyz
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: vault-ingressroute
+  namespace: vault
+  annotations:
+    external-dns.alpha.kubernetes.io/target: 10.0.10.21
+    kubernetes.io/ingress.class: traefik
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`vault.lab.biodrone.xyz`)
+      kind: Rule
+      services:
+        - name: vault
+          port: 8200
+  tls:
+    secretName: vault-certificate-production
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: vault-ingress
+  namespace: vault
+spec:
+  ingressClassName: tailscale
+  defaultBackend:
+    service:
+      name: vault
+      port:
+        number: 8200
+  tls:
+    - hosts:
+        - vault
+


### PR DESCRIPTION
This PR adds HashiCorp Vault installation via Helm for secrets management.

## Changes
- Add Vault HelmRepository pointing to HashiCorp official Helm repo
- Configure Vault HelmRelease in standalone mode with persistent storage
- Create explicit PVC (vault-data) using nfs-truenas storage class
- Configure TLS certificate for vault.lab.biodrone.xyz
- Add Traefik IngressRoute for internal HTTPS access with valid TLS
- Add Tailscale Ingress for VPN access
- Add Vault to infrastructure controllers kustomization

## Configuration
- **Mode**: Standalone (single replica) - suitable for initial setup
- **Storage**: 10Gi PVC on nfs-truenas storage class
- **Access**: Internal via Traefik (vault.lab.biodrone.xyz) and Tailscale VPN
- **UI**: Enabled for web-based management

## Next Steps (after merge)
1. Initialize Vault (generate unseal keys and root token)
2. Unseal Vault using the unseal keys
3. Configure Kubernetes authentication
4. Set up Vault policies and roles

Closes #27